### PR TITLE
Don’t call gem

### DIFF
--- a/lib/compat/multi_json.rb
+++ b/lib/compat/multi_json.rb
@@ -1,4 +1,3 @@
-gem 'multi_json', '>= 1.0.0'
 require 'multi_json'
 
 unless MultiJson.respond_to?(:load)


### PR DESCRIPTION
In `lib/compat/multi_json.rb` there is a call to `Kernel#gem`. Normally these things will be handled by Bundler so it is unclear why this is here.

This causes a problem when using https://github.com/iconara/puck since it doesn’t actually include gem specs but sets up required gems statically in a jar-file, causing the call to fail.

The solution is to simply remove that call.
